### PR TITLE
re-introduce explicit requirements.txt, despite the duplication with setup.py

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,14 @@
--e ./
+django<1.9
+dj-static==0.0.6 # Serve Static files from WSGI server
+
+# Image Support
+Pillow==2.5.3
+
+dj-database-url==0.3.0 # Use DB_URL environment variable
+PyYAML==3.11 # Fixtures
+
+# Third Party Plugins
+django-endless-pagination==2.0
+django-gravatar2==1.1.3
+django-parsley
+

--- a/requirements/staging.txt
+++ b/requirements/staging.txt
@@ -1,3 +1,4 @@
 -r base.txt
 
 djrill==1.3.0 # Send email from Mandrill
+psycopg2>2.5


### PR DESCRIPTION
The clever -e . thingie in base.txt wasn't working...