### PR TITLE
Remove useless params from fields to remove warning in syncdb. (null=…

### DIFF
--- a/connect/accounts/migrations/0005_auto_20150605_2314.py
+++ b/connect/accounts/migrations/0005_auto_20150605_2314.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0004_auto_20150605_remove_first_name_last_name'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='customuser',
+            name='roles',
+            field=models.ManyToManyField(verbose_name='role', to='accounts.Role', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='userskill',
+            name='proficiency',
+            field=models.IntegerField(verbose_name='proficiency', choices=[('', '---------'), (10, 'Beginner'), (20, 'Intermediate'), (30, 'Advanced'), (40, 'Expert')], default=10),
+        ),
+    ]

--- a/connect/accounts/models.py
+++ b/connect/accounts/models.py
@@ -93,8 +93,7 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
     # Custom connect fields
     bio = models.TextField(_('biography'), blank=True)
 
-    roles = models.ManyToManyField('Role', verbose_name=_('role'),
-                                   null=True, blank=True)
+    roles = models.ManyToManyField('Role', verbose_name=_('role'), blank=True)
 
     is_moderator = models.BooleanField(
         _('moderator status'), default=False,
@@ -388,7 +387,6 @@ class UserSkill(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_("user"))
     skill = models.ForeignKey(Skill, verbose_name=_('skill'))
     proficiency = models.IntegerField(_('proficiency'),
-                                      max_length=2,
                                       choices=PROFICIENCY_CHOICES,
                                       default=BEGINNER)
 


### PR DESCRIPTION
…True for m2m and a max_length for an integerField)