### PR TITLE
Make a few byte literals into strings

### DIFF
--- a/bdd/features/steps/close_account.py
+++ b/bdd/features/steps/close_account.py
@@ -11,4 +11,4 @@ def impl(context):
 
 @then('I am redirected to a confirmation page')
 def impl(context):
-    assert b'Account Closed' in context.browser.title
+    assert 'Account Closed' in context.browser.title

--- a/bdd/features/steps/common.py
+++ b/bdd/features/steps/common.py
@@ -220,8 +220,8 @@ def impl(context, link_text):
 # Common Redirects
 @then('I am redirected to my dashboard')
 def impl(context):
-    assert b'Dashboard' in context.browser.title
+    assert 'Dashboard' in context.browser.title
 
 @then('I am redirected to the login page')
 def impl(context):
-    assert b'Login' in context.browser.title
+    assert 'Login' in context.browser.title


### PR DESCRIPTION
Running the BDD tests, I had several failures that complained about incorrectly comparing bytes with strings.  There were several uses of byte literals (`b'something'`) in steps, and there wasn't an obvious reason why they were byte literals, changing them to strings seems to fix it.

This is under python 3.4.