### PR TITLE
BDD: Print page text if cannot find text on page

### DIFF
--- a/bdd/features/steps/common.py
+++ b/bdd/features/steps/common.py
@@ -208,7 +208,10 @@ def impl(context):
 # Form Errors and Confirmation Messages
 @then('I see "{message}"')
 def impl(context, message):
-    assert context.browser.is_text_present(message, wait_time=30)
+    if not context.browser.is_text_present(message, wait_time=3):
+        raise AssertionError('could not find {message!r} in page body:\n{body}'.format(
+            message=message, body=context.browser.find_by_tag('body').text
+        ))
 
 
 # Clicking on an link by text


### PR DESCRIPTION
I was seeing some failures in BDD tests that use the `I see {message}` step, and they were just saying "AssertionError", which wasn't very helpful for debugging what was going on.

This is one possible fix, where we print out saying "could not find x in page text y".  May not be scalable if pages grow to be much bigger or text-heavy than they currently are tho?

Oh, I also cut the wait down to 3 seconds.  You might not agree with that, so feel free to switch it back.  But it worked for me!