### PR TITLE
Add a general DEFAULT_WAIT constant for all the wait_times in bdd tests

### DIFF
--- a/bdd/features/steps/common.py
+++ b/bdd/features/steps/common.py
@@ -1,9 +1,10 @@
-import factory
-from behave import *
-from splinter.exceptions import ElementDoesNotExist
+from behave import given, when, then
 from django.core import management
-from connect.accounts.factories import (InvitedPendingFactory, ModeratorFactory,
-                                RequestedPendingFactory, UserFactory)
+from connect.accounts.factories import (
+    InvitedPendingFactory, ModeratorFactory, RequestedPendingFactory, UserFactory
+)
+
+DEFAULT_WAIT = 5
 
 
 # Setting up our users
@@ -208,7 +209,7 @@ def impl(context):
 # Form Errors and Confirmation Messages
 @then('I see "{message}"')
 def impl(context, message):
-    if not context.browser.is_text_present(message, wait_time=3):
+    if not context.browser.is_text_present(message, wait_time=DEFAULT_WAIT):
         raise AssertionError('could not find {message!r} in page body:\n{body}'.format(
             message=message, body=context.browser.find_by_tag('body').text
         ))

--- a/bdd/features/steps/invite_user.py
+++ b/bdd/features/steps/invite_user.py
@@ -1,4 +1,5 @@
-from behave import *
+from behave import given, then
+from common import DEFAULT_WAIT
 
 
 # Unique to Scenario: Moderator invites new user
@@ -13,9 +14,9 @@ def impl(context):
 
 @then('I see that the user has been added to my list of invitations pending activation')
 def impl(context):
-    assert context.browser.is_element_present_by_css('table.invitation-table', wait_time=5)
-    assert context.browser.is_text_present('First Last', wait_time=5)
-    assert context.browser.is_text_present('new.user@test.test', wait_time=5)
-    assert context.browser.is_text_present('Resend Invitation', wait_time=5)
-    assert context.browser.is_text_present('Revoke Invitation', wait_time=5)
+    assert context.browser.is_element_present_by_css('table.invitation-table', wait_time=DEFAULT_WAIT)
+    assert context.browser.is_text_present('First Last', wait_time=DEFAULT_WAIT)
+    assert context.browser.is_text_present('new.user@test.test', wait_time=DEFAULT_WAIT)
+    assert context.browser.is_text_present('Resend Invitation', wait_time=DEFAULT_WAIT)
+    assert context.browser.is_text_present('Revoke Invitation', wait_time=DEFAULT_WAIT)
 

--- a/bdd/features/steps/moderate_abuse_reports.py
+++ b/bdd/features/steps/moderate_abuse_reports.py
@@ -1,5 +1,6 @@
 from connect.accounts.factories import AbuseReportFactory, AbuseWarningFactory
-from behave import *
+from behave import given, then, when
+from common import DEFAULT_WAIT
 
 
 # Background
@@ -27,7 +28,7 @@ def impl(context):
 
 @then('I see existing warnings')
 def impl(context):
-    assert context.browser.is_text_present('One prior warning', wait_time=20)
+    assert context.browser.is_text_present('One prior warning', wait_time=DEFAULT_WAIT)
 
 @then('I cannot see reports relating to myself')
 def impl(context):
@@ -42,8 +43,8 @@ def impl(context):
 @then('I see the prior warnings modal, with information inside it')
 def impl(context):
     assert context.browser.is_text_present('One prior warning for Standard User')
-    assert context.browser.is_text_present('This is a complaint', wait_time=20) # Default from our factory
-    assert context.browser.is_text_present('This is a formal warning', wait_time=20) # Default from our factory
+    assert context.browser.is_text_present('This is a complaint', wait_time=DEFAULT_WAIT) # Default from our factory
+    assert context.browser.is_text_present('This is a formal warning', wait_time=DEFAULT_WAIT) # Default from our factory
     assert context.browser.is_text_present('by Another User')
     assert context.browser.is_text_present('by Moderator User')
 

--- a/bdd/features/steps/review_applications.py
+++ b/bdd/features/steps/review_applications.py
@@ -1,13 +1,14 @@
-from behave import *
+from behave import then
+from common import DEFAULT_WAIT
 
 
 # Unique to Scenario: View applications
 @then('I see a list of pending applications')
 def impl(context):
     assert context.browser.is_element_present_by_css('.review-app-table')
-    assert context.browser.is_text_present('Pending', wait_time=10)
-    assert context.browser.is_text_present('Approval', wait_time=10)
-    assert context.browser.is_text_present('pending.approval@test.test', wait_time=10)
+    assert context.browser.is_text_present('Pending', wait_time=DEFAULT_WAIT)
+    assert context.browser.is_text_present('Approval', wait_time=DEFAULT_WAIT)
+    assert context.browser.is_text_present('pending.approval@test.test', wait_time=DEFAULT_WAIT)
 
 
 # Unique to Scenario Outline: Moderator submits decision

--- a/bdd/features/steps/revoke_invitation.py
+++ b/bdd/features/steps/revoke_invitation.py
@@ -1,4 +1,5 @@
-from behave import *
+from behave import then, when
+from common import DEFAULT_WAIT
 
 
 # Unique to Scenario: Moderator does not confirm revocation
@@ -14,4 +15,4 @@ def impl(context):
 @then('the invited user has been removed from my pending invitations list')
 def impl(context):
     assert context.browser.is_text_not_present('invited.user@test.test',
-                                               wait_time=5)
+                                               wait_time=DEFAULT_WAIT)

--- a/bdd/features/steps/view_dashboard.py
+++ b/bdd/features/steps/view_dashboard.py
@@ -1,8 +1,9 @@
 import factory
-from behave import *
-from django.conf import settings
+from behave import given, then, when
 from connect.accounts.factories import UserFactory, UserSkillFactory
 from connect.accounts.models import Role, Skill
+from common import DEFAULT_WAIT
+
 
 # Background
 @given('the following users exist')
@@ -76,11 +77,11 @@ def impl(context):
 @then('the member card expands')
 def impl(context):
     assert context.browser.is_element_present_by_css('table.skills',
-                                                     wait_time=5)
+                                                     wait_time=DEFAULT_WAIT)
 
 @then('"View Full Profile" turns into "Collapse"')
 def impl(context):
-    assert context.browser.is_text_present('Collapse', wait_time=5)
+    assert context.browser.is_text_present('Collapse', wait_time=DEFAULT_WAIT)
 
 
 # Unique to Scenario: Report Abuse
@@ -91,7 +92,7 @@ def impl(context):
 @then('I am taken to a new page to report that member')
 def impl(context):
     assert context.browser.is_text_present('Log an abuse report against',
-                                           wait_time=5)
+                                           wait_time=DEFAULT_WAIT)
 
 
 # Unique to Scenario: Many users prompt pagination


### PR DESCRIPTION
there were lots of different wait_times all over the place... I figured one (overridable) constant might make things neater / easier to do a global increase or decrease?