### PR TITLE
remove errant tab

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
 [testenv:py34-1.8]
 basepython = python3.4
 deps =
-	Django<1.9
+    Django<1.9
     coverage
 
 [testenv:flake8]


### PR DESCRIPTION
converts a random tab found in tox.ini to spaces like all the other indents.